### PR TITLE
Make schemes stack-safe using Eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bloop/
+.metals/
 target/
 *.class
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.7
+  - 2.12.11
+  - 2.13.2
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ jdk:
   - openjdk11
 
 script:
-  - sbt clean headerCheck coverage test coverageReport
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - sbt clean headerCheck test
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: scala
 
 scala:
-  - 2.11.12
   - 2.12.11
   - 2.13.2
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -77,9 +77,10 @@ lazy val commonSettings = Def.settings(
   releaseCrossBuild := true,
 
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-core" % "1.4.0",
-    "org.typelevel" %% "cats-free" % "1.4.0",
-    "org.typelevel" %% "cats-testkit" % "1.4.0" % Test
+    "org.typelevel" %% "cats-core" % "2.1.1",
+    "org.typelevel" %% "cats-free" % "2.1.1",
+    "org.typelevel" %% "cats-testkit" % "2.1.1" % Test,
+    "org.typelevel" %% "cats-testkit-scalatest" % "1.0.1" % Test
   ),
 
   libraryDependencies ++= {
@@ -95,20 +96,11 @@ lazy val commonSettings = Def.settings(
     headerCreate.in(Compile).triggeredBy(compile.in(Compile)).value
   },
 
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
 
   headerLicense := Some(HeaderLicense.ALv2("2018", "David Gregory and the Schemes project contributors")),
 
   unmanagedSources.in(Compile, headerCreate) ++= (sourceDirectory.in(Compile).value / "boilerplate" ** "*.template").get,
-
-  coursierVerbosity := {
-    val travisBuild = isTravisBuild.in(Global).value
-
-    if (travisBuild)
-      0
-    else
-      coursierVerbosity.value
-  }
 )
 
 lazy val publishSettings = Def.settings(

--- a/core/shared/src/main/scala/schemes/Schemes.scala
+++ b/core/shared/src/main/scala/schemes/Schemes.scala
@@ -118,11 +118,11 @@ object Schemes {
   def postpro[F[_], A](a: A)(post: F ~> F)(coalgebra: A => F[A])(implicit T: Traverse[F]): Eval[Fix[F]] = {
     def loop(a: A): Eval[Fix[F]] = Eval.defer {
       // Unfold the current seed into a layer of F containing the next seed using the coalgebra
-      val outerLayer = post(coalgebra(a))
+      val outerLayer = coalgebra(a)
       // Unfold each inner seed A into a subsequent new layer of F recursively
       val allLayers = T.traverse(outerLayer)(loop)
       // Finish off this layer with a topping of Fix
-      allLayers.map(Fix(_))
+      allLayers.map(f => Fix(post(f)))
     }
 
     loop(a)

--- a/core/shared/src/main/scala/schemes/Schemes.scala
+++ b/core/shared/src/main/scala/schemes/Schemes.scala
@@ -16,18 +16,19 @@
 
 package schemes
 
-import cats.{ Eval, Functor, Monad, Traverse, ~> }
+import cats.{ Eval, Monad, Traverse, ~> }
 import cats.free.Cofree
+import cats.syntax.functor._
 
 object Schemes {
-  def cata[F[_], A](fix: Fix[F])(algebra: F[A] => A)(implicit F: Functor[F]): A = {
-    def loop(fix: Fix[F]): A = {
+  def cata[F[_], A](fix: Fix[F])(algebra: F[A] => A)(implicit T: Traverse[F]): Eval[A] = {
+    def loop(fix: Fix[F]): Eval[A] = Eval.defer {
       // Peel off a layer of Fix to get to the F inside
       val peeled = Fix.unfix(fix)
       // Apply the algebra to all the layers beneath this one
-      val prepared = F.map(peeled)(loop)
+      val prepared = T.traverse(peeled)(loop)
       // Finally apply the algebra to this layer
-      algebra(prepared)
+      prepared.map(algebra)
     }
 
     loop(fix)
@@ -42,17 +43,18 @@ object Schemes {
       // Finally apply the transformation to this layer
       M.flatMap(prepared)(algebra)
     }
+
     loop(fix)
   }
 
-  def ana[F[_], A](a: A)(coalgebra: A => F[A])(implicit F: Functor[F]): Fix[F] = {
-    def loop(a: A): Fix[F] = {
+  def ana[F[_], A](a: A)(coalgebra: A => F[A])(implicit T: Traverse[F]): Eval[Fix[F]] = {
+    def loop(a: A): Eval[Fix[F]] = Eval.defer {
       // Unfold the current seed into a layer of F containing the next seed using the coalgebra
       val currentLayer = coalgebra(a)
       // Unfold each inner seed A into a subsequent new layer of F recursively
-      val allLayers = F.map(currentLayer)(loop)
+      val allLayers = T.traverse(currentLayer)(loop)
       // Finish off this layer with a topping of Fix
-      Fix[F](allLayers)
+      allLayers.map(Fix(_))
     }
 
     loop(a)
@@ -73,14 +75,14 @@ object Schemes {
     loop(a)
   }
 
-  def hylo[F[_], A, B](a: A)(coalgebra: A => F[A], algebra: F[B] => B)(implicit F: Functor[F]): B = {
-    def loop(a: A): B = {
+  def hylo[F[_], A, B](a: A)(coalgebra: A => F[A], algebra: F[B] => B)(implicit T: Traverse[F]): Eval[B] = {
+    def loop(a: A): Eval[B] = Eval.defer {
       // Unfold a layer of F using the seed
       val outerLayer = coalgebra(a)
       // Recursively unfold down to the deepest leaves and then fold back up again
-      val refolded = F.map(outerLayer)(loop)
+      val refolded = T.traverse(outerLayer)(loop)
       // Tear the remaining outermost layer back down again
-      algebra(refolded)
+      refolded.map(algebra)
     }
 
     loop(a)
@@ -89,8 +91,7 @@ object Schemes {
   def hyloM[M[_], F[_], A, B](a: A)(coalgebra: A => M[F[A]], algebra: F[B] => M[B])(implicit M: Monad[M], T: Traverse[F]): M[B] = {
     def loop(a: A): M[B] = {
       // Unfold a layer of F using the seed
-      val outerLayer = coalgebra(a)
-      M.flatMap(outerLayer) { fa =>
+      M.flatMap(coalgebra(a)) { fa =>
         // Recursively unfold down to the deepest leaves and then fold back up again
         val refolded = T.traverse(fa)(loop)
         // Tear the remaining outermost layer back down again
@@ -101,68 +102,59 @@ object Schemes {
     loop(a)
   }
 
-  def prepro[F[_], A](fix: Fix[F])(pre: F ~> F, algebra: F[A] => A)(implicit F: Functor[F]): A = {
-    def loop(fix: Fix[F]): A = {
+  def prepro[F[_], A](fix: Fix[F])(pre: F ~> F)(algebra: F[A] => A)(implicit T: Traverse[F]): Eval[A] = {
+    def loop(fix: Fix[F]): Eval[A] = Eval.defer {
       // Peel off a layer of Fix to get to the F inside
-      val peeled = Fix.unfix(fix)
+      val peeled = pre(Fix.unfix(fix))
       // Apply the algebra to all the layers beneath this one
-      val prepared = F.map(peeled) { fixf =>
-        // Apply the transformation at each layer before handing over to the recursive call
-        val transformed = cata[F, Fix[F]](fixf) { fa => Fix[F](pre(fa)) }
-        loop(transformed)
-      }
+      val prepared = T.traverse(peeled)(loop)
       // Finally apply the algebra to this layer
-      algebra(prepared)
+      prepared.map(algebra)
     }
 
     loop(fix)
   }
 
-  def postpro[F[_], A](a: A)(coalgebra: A => F[A], post: F ~> F)(implicit F: Functor[F]): Fix[F] = {
-    def loop(a: A): Fix[F] = {
+  def postpro[F[_], A](a: A)(post: F ~> F)(coalgebra: A => F[A])(implicit T: Traverse[F]): Eval[Fix[F]] = {
+    def loop(a: A): Eval[Fix[F]] = Eval.defer {
       // Unfold the current seed into a layer of F containing the next seed using the coalgebra
-      val outerLayer = coalgebra(a)
+      val outerLayer = post(coalgebra(a))
       // Unfold each inner seed A into a subsequent new layer of F recursively
-      val allLayers = F.map(outerLayer) { aa =>
-        ana[F, Fix[F]](loop(aa)) { fixf =>
-          // Apply the transformation to each newly unfolded layer after receiving the results of the recursive call
-          post(Fix.unfix(fixf))
-        }
-      }
+      val allLayers = T.traverse(outerLayer)(loop)
       // Finish off this layer with a topping of Fix
-      Fix[F](allLayers)
+      allLayers.map(Fix(_))
     }
 
     loop(a)
   }
 
-  def elgot[F[_], A, B](a: A)(elgotCoalgebra: A => Either[B, F[A]], algebra: F[B] => B)(implicit F: Functor[F]): B = {
-    def loop(a: A): B = {
+  def elgot[F[_], A, B](a: A)(elgotCoalgebra: A => Either[B, F[A]], algebra: F[B] => B)(implicit T: Traverse[F]): Eval[B] = {
+    def loop(a: A): Eval[B] = Eval.defer {
       // Unfold a layer of F using the seed
       elgotCoalgebra(a) match {
         // Each unfolding can either continue the computation or complete it with B
         case Right(fa) =>
           // If Right, continue the refold to at least the next layer
-          val allLayers = F.map(fa)(loop)
+          val allLayers = T.traverse(fa)(loop)
           // Finally apply the algebra to tear down this layer
-          algebra(allLayers)
+          allLayers.map(algebra)
         case Left(b) =>
           // If Left, short-circuit by returning a B to complete the refold early
-          b
+          Eval.now(b)
       }
     }
 
     loop(a)
   }
 
-  def coelgot[F[_], A, B](a: A)(coalgebra: A => F[A], elgotAlgebra: (A, () => F[B]) => B)(implicit F: Functor[F]): B = {
-    def loop(a: A): B = {
+  def coelgot[F[_], A, B](a: A)(coalgebra: A => F[A], elgotAlgebra: (A, () => Eval[F[B]]) => Eval[B])(implicit T: Traverse[F]): Eval[B] = {
+    def loop(a: A): Eval[B] = Eval.defer {
       // Construct a function which continues the computation
       val continue = () => {
         // Unfold the current seed into a layer of F containing the next seed using the coalgebra
         val currentLayer = coalgebra(a)
         // Recursively unfold down to the deepest leaves and then fold back up again
-        F.map(currentLayer)(loop)
+        T.traverse(currentLayer)(loop)
       }
 
       // Pass the current seed and the continuation to an algebra which decides whether to continue
@@ -172,61 +164,61 @@ object Schemes {
     loop(a)
   }
 
-  def para[F[_], A](fix: Fix[F])(algebra: F[(Fix[F], A)] => A)(implicit F: Functor[F]): A = {
-    def loop(fix: Fix[F]): A = {
+  def para[F[_], A](fix: Fix[F])(algebra: F[(Fix[F], A)] => A)(implicit T: Traverse[F]): Eval[A] = {
+    def loop(fix: Fix[F]): Eval[A] = Eval.defer {
       // Peel off a layer of Fix to get to the F inside
-      val peeled = fix.unfix
+      val peeled = Fix.unfix(fix)
       // Apply the algebra to all the layers beneath this one, passing along the current subtree
-      val prepared = F.map(peeled)(f => (f, loop(f)))
+      val prepared = T.traverse(peeled)(f => loop(f).tupleLeft(f))
       // Finally apply the algebra to this layer
-      algebra(prepared)
+      prepared.map(algebra)
     }
 
     loop(fix)
   }
 
-  def apo[F[_], A](a: A)(coalgebra: A => F[Either[Fix[F], A]])(implicit F: Functor[F]): Fix[F] = {
-    def continue(choice: Either[Fix[F], A]): Fix[F] = choice match {
+  def apo[F[_], A](a: A)(coalgebra: A => F[Either[Fix[F], A]])(implicit T: Traverse[F]): Eval[Fix[F]] = {
+    def continue(choice: Either[Fix[F], A]): Eval[Fix[F]] = choice match {
       // If Right, continue unfolding the structure
       case Right(a) => loop(a)
       // If Left, complete with the current structure
-      case Left(fix) => fix
+      case Left(fix) => Eval.now(fix)
     }
 
-    def loop(a: A): Fix[F] = {
+    def loop(a: A): Eval[Fix[F]] = Eval.defer {
       // Unfold the current seed into a layer of F containing the next seed using the coalgebra
       val currentLayer = coalgebra(a)
       // Unfold each inner seed A into a subsequent new layer of F recursively
-      val allLayers = F.map(currentLayer)(continue)
+      val allLayers = T.traverse(currentLayer)(continue)
       // Finish off this layer with a topping of Fix
-      Fix[F](allLayers)
+      allLayers.map(Fix(_))
     }
 
     loop(a)
   }
 
-  def histo[F[_], A](fix: Fix[F])(algebra: F[Cofree[F, A]] => A)(implicit F: Functor[F]): A = {
-    def continue(fix: Fix[F]): F[Cofree[F, A]] = {
+  def histo[F[_], A](fix: Fix[F])(algebra: F[Cofree[F, A]] => A)(implicit T: Traverse[F]): Eval[A] = {
+    def continue(fix: Fix[F]): Eval[F[Cofree[F, A]]] = Eval.defer {
       // Peel off a layer of Fix to get to the F inside
       val peeled = fix.unfix
       // Annotate the contents
-      F.map(peeled)(annotate)
+      T.traverse(peeled)(annotate)
     }
 
-    def annotate(fix: Fix[F]): Cofree[F, A] = {
+    def annotate(fix: Fix[F]): Eval[Cofree[F, A]] = Eval.defer {
       // Get the folded value for this layer
       val head = loop(fix)
       // Apply the algebra to all the layers beneath this one
-      val tail = Eval.later(continue(fix))
+      val tail = continue(fix)
       // Return the subtree annotated with the folded value
-      Cofree(head, tail)
+      head.map(Cofree(_, tail))
     }
 
-    def loop(fix: Fix[F]): A = {
+    def loop(fix: Fix[F]): Eval[A] = Eval.defer {
       // Start the fold from the current layer
       val annotated = continue(fix)
       // Apply the algebra to this layer
-      algebra(annotated)
+      annotated.map(algebra)
     }
 
     loop(fix)

--- a/core/shared/src/main/scala/schemes/data/ListF.scala
+++ b/core/shared/src/main/scala/schemes/data/ListF.scala
@@ -30,17 +30,24 @@ object ListF {
   def nil[A]: Fix[ListF[A, ?]] =
     Fix(NilF())
 
-  def apply[A](as: A*): Fix[ListF[A, ?]] =
+  def apply[A](as: A*): Eval[Fix[ListF[A, ?]]] =
     Schemes.ana[ListF[A, ?], List[A]](as.toList) {
       case Nil => NilF()
       case h :: t => ConsF(h, t)
     }
 
-  def toList[A](list: Fix[ListF[A, ?]]): List[A] =
+  def toList[A](list: Fix[ListF[A, ?]]): Eval[List[A]] =
     Schemes.cata[ListF[A, ?], List[A]](list) {
       case NilF() => Nil
       case ConsF(h, t) => h :: t
     }
+
+  implicit class SchemesListFOps[A](list: Fix[ListF[A, ?]]) {
+    def length: Eval[Long] = Schemes.cata[ListF[A, ?], Long](list) {
+      case ConsF(_, tail) => tail + 1L
+      case NilF() => 0L
+    }
+  }
 
   implicit def schemesListFEq[A, B](implicit A: Eq[A], B: Eq[B]) = new Eq[ListF[A, B]] {
     def eqv(l: ListF[A, B], r: ListF[A, B]) = (l, r) match {

--- a/core/shared/src/main/scala/schemes/data/ListF.scala
+++ b/core/shared/src/main/scala/schemes/data/ListF.scala
@@ -42,13 +42,6 @@ object ListF {
       case ConsF(h, t) => h :: t
     }
 
-  implicit class SchemesListFOps[A](list: Fix[ListF[A, ?]]) {
-    def length: Eval[Long] = Schemes.cata[ListF[A, ?], Long](list) {
-      case ConsF(_, tail) => tail + 1L
-      case NilF() => 0L
-    }
-  }
-
   implicit def schemesListFEq[A, B](implicit A: Eq[A], B: Eq[B]) = new Eq[ListF[A, B]] {
     def eqv(l: ListF[A, B], r: ListF[A, B]) = (l, r) match {
       case (NilF(), NilF()) => true

--- a/core/shared/src/main/scala/schemes/package.scala
+++ b/core/shared/src/main/scala/schemes/package.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import cats.{ ~>, Functor, Monad, Traverse }
+import cats.{ ~>, Eval, Monad, Traverse }
 import cats.free.Cofree
 
 package object schemes {
@@ -22,44 +22,44 @@ package object schemes {
   type Fix[F[_]] = Fix.Fix[F]
 
   implicit class AnyOps[A](private val a: A) extends AnyVal {
-    def ana[F[_]](coalgebra: A => F[A])(implicit F: Functor[F]): Fix[F] =
+    def ana[F[_]](coalgebra: A => F[A])(implicit T: Traverse[F]): Eval[Fix[F]] =
       Schemes.ana(a)(coalgebra)
 
     def anaM[M[_], F[_]](coalgebra: A => M[F[A]])(implicit M: Monad[M], T: Traverse[F]): M[Fix[F]] =
       Schemes.anaM(a)(coalgebra)
 
-    def hylo[F[_], B](coalgebra: A => F[A], algebra: F[B] => B)(implicit F: Functor[F]): B =
+    def hylo[F[_], B](coalgebra: A => F[A], algebra: F[B] => B)(implicit T: Traverse[F]): Eval[B] =
       Schemes.hylo(a)(coalgebra, algebra)
 
     def hyloM[M[_], F[_], B](coalgebra: A => M[F[A]], algebra: F[B] => M[B])(implicit M: Monad[M], T: Traverse[F]): M[B] =
       Schemes.hyloM(a)(coalgebra, algebra)
 
-    def postpro[F[_]](coalgebra: A => F[A], post: F ~> F)(implicit F: Functor[F]): Fix[F] =
-      Schemes.postpro(a)(coalgebra, post)
+    def postpro[F[_]](post: F ~> F)(coalgebra: A => F[A])(implicit T: Traverse[F]): Eval[Fix[F]] =
+      Schemes.postpro(a)(post)(coalgebra)
 
-    def elgot[F[_], B](elgotCoalgebra: A => Either[B, F[A]], algebra: F[B] => B)(implicit F: Functor[F]): B =
+    def elgot[F[_], B](elgotCoalgebra: A => Either[B, F[A]], algebra: F[B] => B)(implicit T: Traverse[F]): Eval[B] =
       Schemes.elgot(a)(elgotCoalgebra, algebra)
 
-    def coelgot[F[_], B](coalgebra: A => F[A], elgotAlgebra: (A, () => F[B]) => B)(implicit F: Functor[F]): B =
+    def coelgot[F[_], B](coalgebra: A => F[A], elgotAlgebra: (A, () => Eval[F[B]]) => Eval[B])(implicit T: Traverse[F]): Eval[B] =
       Schemes.coelgot(a)(coalgebra, elgotAlgebra)
 
-    def apo[F[_]](coalgebra: A => F[Either[Fix[F], A]])(implicit F: Functor[F]): Fix[F] =
+    def apo[F[_]](coalgebra: A => F[Either[Fix[F], A]])(implicit T: Traverse[F]): Eval[Fix[F]] =
       Schemes.apo(a)(coalgebra)
   }
 
   implicit class FixOps[F[_]](private val fix: Fix[F]) extends AnyVal {
     def unfix: F[Fix[F]] = Fix.unfix(fix)
 
-    def cata[A](algebra: F[A] => A)(implicit F: Functor[F]): A =
+    def cata[A](algebra: F[A] => A)(implicit T: Traverse[F]): Eval[A] =
       Schemes.cata(fix)(algebra)
 
     def cataM[M[_], A](algebra: F[A] => M[A])(implicit M: Monad[M], T: Traverse[F]): M[A] =
       Schemes.cataM(fix)(algebra)
 
-    def prepro[A](pre: F ~> F, algebra: F[A] => A)(implicit F: Functor[F]): A =
-      Schemes.prepro(fix)(pre, algebra)
+    def prepro[A](pre: F ~> F)(algebra: F[A] => A)(implicit T: Traverse[F]): Eval[A] =
+      Schemes.prepro(fix)(pre)(algebra)
 
-    def histo[A](algebra: F[Cofree[F, A]] => A)(implicit F: Functor[F]): A =
+    def histo[A](algebra: F[Cofree[F, A]] => A)(implicit T: Traverse[F]): Eval[A] =
       Schemes.histo(fix)(algebra)
   }
 }

--- a/core/shared/src/test/scala/schemes/SchemesSpec.scala
+++ b/core/shared/src/test/scala/schemes/SchemesSpec.scala
@@ -156,8 +156,15 @@ class SchemesSpec extends AnyFlatSpec with Matchers {
       case other => other
     }
 
-    1.postpro[ListF[Int, ?]](stopAtMillion) { i =>
+    val length = (list: Fix[ListF[Int, ?]]) => Schemes.cata[ListF[Int, ?], Long](list) {
+      case ConsF(_, tail) => 1L + tail
+      case NilF() => 0L
+    }
+
+    val unfolded = 1.postpro[ListF[Int, ?]](stopAtMillion) { i =>
       if (i > 2000000) NilF() else ConsF(i, i + 1)
-    }.value.length.value shouldBe 1000000
+    }.value
+
+    length(unfolded).value shouldBe 1000000
   }
 }

--- a/core/shared/src/test/scala/schemes/SchemesSpec.scala
+++ b/core/shared/src/test/scala/schemes/SchemesSpec.scala
@@ -1,6 +1,7 @@
 package schemes
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats._
 import schemes.data._
@@ -50,7 +51,7 @@ object MathExpr {
   }
 }
 
-class SchemesSpec extends FlatSpec with Matchers {
+class SchemesSpec extends AnyFlatSpec with Matchers {
   "unfix" should "unwrap a single layer of Fix" in {
     import MathExpr._
     add(num(1), num(1)).unfix shouldBe Add[Fix[MathExpr]](num(1), num(1))
@@ -60,13 +61,13 @@ class SchemesSpec extends FlatSpec with Matchers {
     import MathExpr._
 
     val two = add(num(1), num(1))
-    two.cata(evalAlgebra) shouldBe 2
+    two.cata(evalAlgebra).value shouldBe 2
 
     val four = mul(num(2), num(2))
-    four.cata(evalAlgebra) shouldBe 4
+    four.cata(evalAlgebra).value shouldBe 4
 
     val sixteen = add(num(2), add(num(3), num(11)))
-    sixteen.cata(evalAlgebra) shouldBe 16
+    sixteen.cata(evalAlgebra).value shouldBe 16
 
     two.cataM[Id, Int](evalAlgebra) shouldBe 2
   }
@@ -79,7 +80,7 @@ class SchemesSpec extends FlatSpec with Matchers {
         Num(i)
       else
         Add(1, i - 1)
-    }
+    }.value
 
     val unfoldAddM = 5.anaM[Id, MathExpr] { i =>
       if (i < 2)
@@ -98,7 +99,7 @@ class SchemesSpec extends FlatSpec with Matchers {
 
     5.hylo[MathExpr, Int](
       i => if (i < 2) Num(i) else Add(1, i - 1),
-      evalAlgebra) shouldBe 5
+      evalAlgebra).value shouldBe 5
 
     5.hyloM[Id, MathExpr, Int](
       i => if (i < 2) Num(i) else Add(1, i - 1),
@@ -116,11 +117,24 @@ class SchemesSpec extends FlatSpec with Matchers {
       case other => other
     }
 
-    val `1 to 10` = ListF(1 to 10: _*)
+    val `1 to 10` = ListF(1 to 10: _*).value
 
-    `1 to 10`.prepro[Int](
-      stopAtFive,
-      sum) shouldBe 15
+    `1 to 10`.prepro[Int](stopAtFive)(sum).value shouldBe 15
+  }
+
+  it should "be stack-safe" in {
+    val stopAtMillion = Lambda[ListF[Int, ?] ~> ListF[Int, ?]] {
+      case ConsF(n, _) if n > 1000000 => NilF()
+      case other => other
+    }
+
+    val lots = (1 to 2000000).toList
+    val lotsF = ListF(lots: _*).value
+
+    lotsF.prepro[List[Int]](stopAtMillion) {
+      case NilF() => Nil
+      case ConsF(h, t) => h :: t
+    }.value.length shouldBe 1000000
   }
 
   "postpro" should "apply a transformation at each layer after unfolding some structure" in {
@@ -129,10 +143,21 @@ class SchemesSpec extends FlatSpec with Matchers {
       case other => other
     }
 
-    val `1 to 5` = ListF(1 to 5: _*)
+    val `1 to 5` = ListF(1 to 5: _*).value
 
-    1.postpro[ListF[Int, ?]](
-      i => if (i > 100) NilF() else ConsF(i, i + 1),
-      stopAtFive) shouldBe `1 to 5`
+    1.postpro[ListF[Int, ?]](stopAtFive) { i =>
+      if (i > 100) NilF() else ConsF(i, i + 1)
+    }.value shouldBe `1 to 5`
+  }
+
+  it should "be stack-safe" in {
+    val stopAtMillion = Lambda[ListF[Int, ?] ~> ListF[Int, ?]] {
+      case ConsF(n, _) if n > 1000000 => NilF()
+      case other => other
+    }
+
+    1.postpro[ListF[Int, ?]](stopAtMillion) { i =>
+      if (i > 2000000) NilF() else ConsF(i, i + 1)
+    }.value.length.value shouldBe 1000000
   }
 }

--- a/core/shared/src/test/scala/schemes/SyntaxSpec.scala
+++ b/core/shared/src/test/scala/schemes/SyntaxSpec.scala
@@ -1,6 +1,6 @@
 package schemes
 
-import cats.{ ~>, Monad, Traverse }
+import cats.{ ~>, Eval, Monad, Traverse }
 import cats.free.Cofree
 
 /* Check that usages of extension methods compile */
@@ -15,13 +15,13 @@ object SyntaxSpec {
     val algebraM = mock[F[B] => M[B]]
     val natTrans = mock[F ~> F]
     val elgotCoalgebra = mock[A => Either[B, F[A]]]
-    val elgotAlgebra = mock[(A, () => F[B]) => B]
+    val elgotAlgebra = mock[(A, () => Eval[F[B]]) => Eval[B]]
     val rCoalgebra = mock[A => F[Either[Fix[F], A]]]
     a.ana(coalgebra)
     a.anaM(coalgebraM)
     a.hylo(coalgebra, algebra)
     a.hyloM(coalgebraM, algebraM)
-    a.postpro(coalgebra, natTrans)
+    a.postpro(natTrans)(coalgebra)
     a.elgot(elgotCoalgebra, algebra)
     a.coelgot(coalgebra, elgotAlgebra)
     a.apo(rCoalgebra)
@@ -37,7 +37,7 @@ object SyntaxSpec {
     fix.unfix
     fix.cata(algebra)
     fix.cataM(algebraM)
-    fix.prepro(natTrans, algebra)
+    fix.prepro(natTrans)(algebra)
     fix.histo(cvAlgebra)
     ()
   }

--- a/core/shared/src/test/scala/schemes/data/ListFSpec.scala
+++ b/core/shared/src/test/scala/schemes/data/ListFSpec.scala
@@ -18,13 +18,21 @@ class ListFSpec extends CatsSuite {
   checkAll("ListF[Int, Int]", TraverseTests[ListF[Int, ?]].traverse[Int, Int, Int, Set[Int], Option, Option])
 
   val list = List(1, 2, 3, 4, 5)
-  val listF = ListF(1 to 5: _*)
+  val listF = ListF(1 to 5: _*).value
 
   test("ListF.apply") {
     listF shouldBe ListF.cons(1, ListF.cons(2, ListF.cons(3, ListF.cons(4, ListF.cons(5, ListF.nil[Int])))))
   }
 
   test("ListF.toList") {
-    ListF.toList(listF) shouldBe list
+    ListF.toList(listF).value shouldBe list
+  }
+
+  test("ListF.apply is stack-safe") {
+    ListF(1 to 1000000: _*).value
+  }
+
+  test("ListF.toList is stack-safe") {
+    ListF.toList(ListF(1 to 1000000: _*).value).value
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.6
+sbt.version=1.3.13
 

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,0 @@
-coursierVerbosity := 0
-

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,4 @@
+// DO NOT EDIT! This file is auto-generated.
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1-229-b7c15aa9")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,27 +1,27 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.9")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
 
-addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.3")
-
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
 addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.24")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.4")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.13")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.1")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")


### PR DESCRIPTION
Makes the schemes in this project stack safe using the awesome idea from [this gist](https://gist.github.com/Baccata/5fb6e9784992b2a467aa1c846d4585c2) by @Baccata.

Things I still need to do:
* Add stack-safety tests for some of the schemes
* Try to unpick the tangled logic of some of the more obscure schemes (e.g. `histo`)

Questions I still have:

* How much slower is it?!?!! :stuck_out_tongue:
* How much of a problem is it in practice to have the more restrictive `Traverse` constraint
* Can I rewrite the monadic schemes to use `tailRecM`?
* What are the laws for `prepro` and `postpro`? I have fiddled with the implementations and want to make sure the transformations happen in the right place - I can probably look in one of the other recursion schemes libraries for this
* Is it more efficient to add stack-safety using the approach described [here](https://blog.functorial.com/posts/2017-06-18-Stack-Safe-Traversals-via-Dissection.html), using a type class which decomposes the data structure rather than relying on Eval to make `traverse` stack-safe?